### PR TITLE
removed limit in trends

### DIFF
--- a/backend/utils/statsUtils/trendsUtils.js
+++ b/backend/utils/statsUtils/trendsUtils.js
@@ -38,9 +38,9 @@ export const mostParticipatedFoods = async () => {
 
             // limit the results
 
-            {
-                $limit: 10,
-            },
+            // {
+            //     $limit: 10,
+            // },
 
             // join food meta data
 


### PR DESCRIPTION
changed the limit of top participated food items from 10 to none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a hard limit on trend results, allowing more data to be returned in API responses instead of being restricted to a fixed maximum.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->